### PR TITLE
Add shortcut targets for dialyzer.

### DIFF
--- a/tools.mk
+++ b/tools.mk
@@ -1,5 +1,8 @@
 REBAR ?= ./rebar
 
+compile-no-deps:
+	${REBAR} compile skip_deps=true
+
 test: compile
 	${REBAR} eunit skip_deps=true
 
@@ -31,7 +34,7 @@ ${LOCAL_PLT}: compile
 		fi \
 	fi
 
-dialyzer: ${PLT} ${LOCAL_PLT}
+dialyzer-run:
 	@echo "==> $(shell basename $(shell pwd)) (dialyzer)"
 	@if [ -f $(LOCAL_PLT) ]; then \
 		PLTS="$(PLT) $(LOCAL_PLT)"; \
@@ -50,6 +53,10 @@ dialyzer: ${PLT} ${LOCAL_PLT}
 	else \
 		dialyzer $(DIALYZER_FLAGS) --plts $${PLTS} -c ebin; \
 	fi
+
+dialyzer-quick: compile-no-deps dialyzer-run
+
+dialyzer: ${PLT} ${LOCAL_PLT} dialyzer-run
 
 cleanplt:
 	@echo


### PR DESCRIPTION
When you're iterating over dialyzer warnings in a project with many
deps, the expense of the dialyzer target gets to be too much since it
takes the safe route of fetching deps, compiling everything, checking
both PLTs, and then running dialyzer. The shortcut target only
compiles the top-level project and then runs dialyzer without
checking/rebuilding the PLTs first.
