### PR TITLE
add simple formatter using emacs

### DIFF
--- a/erlfmt.el
+++ b/erlfmt.el
@@ -1,0 +1,36 @@
+(defun find-erlang-el (erl)
+  (concat
+   (car (file-expand-wildcards
+         (concat
+          (concat
+           (file-name-directory (directory-file-name
+                                 (file-name-directory erl)))
+           "lib")
+          "/erlang/lib/tools-*")))
+   "/emacs/"))
+
+(setq erlang-el (find-erlang-el (executable-find "erl")))
+(print erlang-el)
+
+(setq load-path (cons erlang-el load-path))
+(require 'erlang-start)
+
+(setq-default tab-width 4 indent-tabs-mode nil)
+
+(print argv)
+
+(defun fmt (filename)
+  (find-file filename)
+  (erlang-indent-region (point-min) (point-max))
+  (delete-trailing-whitespace)
+  (save-buffer)
+  (kill-buffer))
+
+(defun fmtall (files)
+  (when files
+    (fmt (car files))
+    (print (car files))
+    (fmtall (cdr files))))
+
+(fmtall argv)
+

--- a/tools.mk
+++ b/tools.mk
@@ -67,3 +67,8 @@ cleanplt:
 	rm $(PLT)
 	rm $(LOCAL_PLT)
 
+fmt:
+	emacs --script $(PRIV_DIR)/erlfmt.el src/*.erl include/*.hrl
+	emacs --script $(PRIV_DIR)/erlfmt.el test/*.erl
+	emacs --script $(PRIV_DIR)/erlfmt.el riak_test/src/*.erl
+	emacs --script $(PRIV_DIR)/erlfmt.el riak_test/tests/*.erl


### PR DESCRIPTION
moved from https://github.com/basho/riak_cs/pull/783 . I would have embed whole elisp codes into tools.mk or it's too confusing compared with having the tool as another file.