### PR TITLE
Change leading \s to [[:space:]].

### DIFF
--- a/tools.mk
+++ b/tools.mk
@@ -47,7 +47,7 @@ dialyzer-run:
 			exit 1; \
 		fi; \
 		dialyzer $(DIALYZER_FLAGS) --plts $${PLTS} -c ebin > dialyzer_warnings ; \
-		egrep -v "^\s*(done|Checking|Proceeding|Compiling)" dialyzer_warnings | grep -F -f dialyzer.ignore-warnings -v > dialyzer_unhandled_warnings ; \
+		egrep -v "^[[:space:]]*(done|Checking|Proceeding|Compiling)" dialyzer_warnings | grep -F -f dialyzer.ignore-warnings -v > dialyzer_unhandled_warnings ; \
 		cat dialyzer_unhandled_warnings ; \
 		[ $$(cat dialyzer_unhandled_warnings | wc -l) -eq 0 ] ; \
 	else \


### PR DESCRIPTION
As found in basho/riak_pb#94, on FreeBSD 9, the "\s" shortcut
character class leads to not filtering out the desired lines, meaning
we were left with a non-empty dialyzer_unhandled_warnings, even if all
known warnings were filtered by the second grep. Changing this to
[[:space:]] resolves the issue, and is more consistent with the
previous 'grep' call in the step.
