### PR TITLE
Show original line numbers even when ignored

### DIFF
--- a/tools.mk
+++ b/tools.mk
@@ -59,7 +59,7 @@ dialyzer-run:
 #   - Anchor to match the entire line (^entire line$)
 #   - Save in dialyzer_unhandled_warnings
 #   - Output matches for those patterns found in the original warnings
-	@-if [ -f $(LOCAL_PLT) ]; then \
+	@if [ -f $(LOCAL_PLT) ]; then \
 		PLTS="$(PLT) $(LOCAL_PLT)"; \
 	else \
 		PLTS=$(PLT); \
@@ -92,7 +92,7 @@ dialyzer-run:
 		    egrep -f dialyzer_unhandled_warnings dialyzer_warnings ; \
 			found_warnings=1; \
 	    fi; \
-		[ "$$found_warnings" == 1 ] ; \
+		[ "$$found_warnings" != 1 ] ; \
 	else \
 		dialyzer $(DIALYZER_FLAGS) --plts $${PLTS} -c ebin; \
 	fi


### PR DESCRIPTION
A previous set of changes now makes tools.mk ignore line numbers when
matching ignored warnings, even though it looks at the number of equal
warnings to make sure and alert the user if we have more than expected.
One side effect of that change is that the line numbers are removed from
the output, which is confusing.
This change improves on that by showing the line numbers from the
original warnings output. It may match some warnings that are already
ignored, but that should be harmless mostly. If anything, it will make
people look at those ignored lines again.

This also fixes a problem with that previous code. Sorting was happening
before the line numbers were removed, so some duplicates may not end up
grouped together.

/cc @reiddraper Please feel free to merge without me after verifying/tweaking.
