### PR TITLE
Update PHONY targets

### DIFF
--- a/tools.mk
+++ b/tools.mk
@@ -1,5 +1,8 @@
 REBAR ?= ./rebar
 
+.PHONY: compile-no-deps test docs xref dialyzer-run dialyzer-quick dialyzer \
+		cleanplt
+
 compile-no-deps:
 	${REBAR} compile skip_deps=true
 


### PR DESCRIPTION
Specifically, the `docs` target would fail to run in any repository that
had a `docs/` directory, like `riak-erlang-client`. This is because the
target was always considered up-to-date. You can test this by running
`make docs -n` with `riak-erlang-client` before and after this tools.mk
change. None of the other PHONY targets are likely to have
file/directory collisions, but it's better to add them just in case.
