### PR TITLE
Fix error in regexp generation for unknown spec type errors

### DIFF
--- a/tools.mk
+++ b/tools.mk
@@ -123,7 +123,7 @@ dialyzer-run:
 		| sed -E 's/^[[:space:]]*[0-9]+[[:space:]]*//' \
 		| sed -E 's/([]\^:+?|()*.$${}\[])/\\\1/g' \
 		| sed -E 's/(\\\.erl\\\:)/\1\\d+:/g' \
-		| sed -E 's/^(.*)$$/^\1$$/g' \
+		| sed -E 's/^(.*)$$/^[[:space:]]*\1$$/g' \
 		> dialyzer_unhandled_warnings ; \
 		rm dialyzer.ignore-warnings.tmp; \
 		if [ $$(cat dialyzer_unhandled_warnings | wc -l) -gt 0 ]; then \


### PR DESCRIPTION
When confronted with this type spec problem:

```
diff --git a/src/riak_kv_vnode_status_mgr.erl b/src/riak_kv_vnode_status_mgr.erl
index 33235b9..5f56121 100644
--- a/src/riak_kv_vnode_status_mgr.erl
+++ b/src/riak_kv_vnode_status_mgr.erl
@@ -271,7 +271,7 @@ read_vnode_status(File) ->
 %% @private write the vnode status. This is why the file is guarded by
 %% the process. This file should have no concurrent access, and MUST
 %% not be written at any other place/time in the system.
--spec write_vnode_status(status(), file:filname()) -> ok.
+-spec write_vnode_status(status(), file:filename()) -> ok.
 write_vnode_status(Status, File) ->
     VersionedStatus = replace(version, ?VNODE_STATUS_VERSION, Status),
     riak_core_util:replace_file(File, io_lib:format("~p.", [VersionedStatus])).
```

... the unpatched version of the sed hackery in `tools.mk` creates
the following:

```
% cat dialyzer_unhandled_warnings
^file\:filname/0$
```

... which does not match the detected error.  Note the two spaces before
the "f" in `file`:

```
% grep :filname dialyzer_warnings
  file:filname/0
```

This patch adds a spec for optional whitespace at the beginning of the line.
