### PR TITLE
Use brancket expression for digit class

### DIFF
--- a/tools.mk
+++ b/tools.mk
@@ -122,7 +122,7 @@ dialyzer-run:
 		| grep -F -f dialyzer.ignore-warnings.tmp -v \
 		| sed -E 's/^[[:space:]]*[0-9]+[[:space:]]*//' \
 		| sed -E 's/([]\^:+?|()*.$${}\[])/\\\1/g' \
-		| sed -E 's/(\\\.erl\\\:)/\1\\d+:/g' \
+		| sed -E 's/(\\\.erl\\\:)/\1[[:digit:]]+:/g' \
 		| sed -E 's/^(.*)$$/^[[:space:]]*\1$$/g' \
 		> dialyzer_unhandled_warnings ; \
 		rm dialyzer.ignore-warnings.tmp; \


### PR DESCRIPTION
`\d` does not work with "egrep (GNU grep) 2.16"  on Ubuntu 14.04.

See also
- http://pubs.opengroup.org/stage7tc1/utilities/grep.html
- http://pubs.opengroup.org/stage7tc1/basedefs/V1_chap09.html