### PR TITLE
Add Common Test support, and add ct to test target

### DIFF
--- a/tools.mk
+++ b/tools.mk
@@ -35,8 +35,13 @@ EUNIT_OPTS ?=
 compile-no-deps:
 	${REBAR} compile skip_deps=true
 
-test: compile
+test: ct eunit
+
+eunit: compile
 	${REBAR} ${EUNIT_OPTS} eunit skip_deps=true
+
+ct: compile
+	${REBAR} ct skip_deps=true
 
 upload-docs: docs
 	@if [ -z "${BUCKET}" -o -z "${PROJECT}" -o -z "${REVISION}" ]; then \


### PR DESCRIPTION
This adds support for Erlang unit tests written in the Common Test framework via the `ct` target, and also adds the `ct` target to the `test` target so that running "make test" will run tests in both EUnit suites and Common Test suites.

If an existing repository doesn't have any Common Test suites implemented, rebar will log that fact and continue, so this should maintain compatibility for existing users of tools.mk without breaking anything.